### PR TITLE
CPU load implementation for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Next
 * [#3](https://github.com/dblock/oshi/pull/3): Mavenized project - [@le-yams](https://github.com/le-yams).
 * Added Travis-CI - [@dblock](https://github.com/dblock).
 * Added TODO list and enhanced README documentation - [@ptitvert](https://github.com/ptitvert)
-* [#15](https://github.com/dblock/oshi/pull/15): Added support for CPU load on OSX and Linux - [@kamenitxan](https://github.com/kamenitxan).
+* [#15](https://github.com/dblock/oshi/pull/15), [#18](https://github.com/dblock/oshi/pull/18): Added support for CPU load - [@kamenitxan](https://github.com/kamenitxan), [@Sorceror](https://github.com/Sorceror).
 * Your contribution here.
 
 

--- a/src/main/java/oshi/software/os/windows/nt/CentralProcessor.java
+++ b/src/main/java/oshi/software/os/windows/nt/CentralProcessor.java
@@ -8,6 +8,7 @@
 package oshi.software.os.windows.nt;
 
 import oshi.hardware.Processor;
+import oshi.util.ExecutingCommand;
 
 /**
  * A CPU as defined in Windows registry.
@@ -136,10 +137,19 @@ public class CentralProcessor implements Processor {
 	 * {@inheritDoc}
 	 */
 	public float getLoad() {
-		throw new UnsupportedOperationException();
+		// this always return whole number value on windows machines
+		String result = ExecutingCommand.getAnswerAt("wmic /locale:ms_409 cpu get loadpercentage", 2);
 
-		// this is from stack overflow. I don't have windows, so I can't test it.
-		// return Float.valueOf(ExecutingCommand.getFirstAnswer("wmic cpu get loadpercentage"));
+		if (result == null || result.isEmpty()) {
+			throw new RuntimeException("CPU load could not be obtained from system");
+		}
+
+		try {
+			return Integer.valueOf(result.trim());
+		} catch (NumberFormatException e) {
+			System.err.println("Cannot parse CPU load value: " + result.trim());
+			throw new RuntimeException("Cannot parse load value: " + result.trim());
+		}
 	}
 
 	@Override

--- a/src/main/java/oshi/util/ExecutingCommand.java
+++ b/src/main/java/oshi/util/ExecutingCommand.java
@@ -37,13 +37,27 @@ public class ExecutingCommand {
 		}
 		return sa;
 	}
-	
-	public static String getFirstAnswer(String cmd2launch) {
-		ArrayList<String> sa = ExecutingCommand
-				.runNative(cmd2launch);
 
-		if (sa != null)
-			return sa.get(0);
+	/**
+	 * Return first line of response for selected command
+	 * @param cmd2launch String command to be launched
+	 * @return String or null
+	 */
+	public static String getFirstAnswer(String cmd2launch) {
+		return getAnswerAt(cmd2launch, 0);
+	}
+
+	/**
+	 * Return response on selected line index (0-based) after running selected command
+	 * @param cmd2launch String command to be launched
+	 * @param answerIdx int index of line in response of the command
+	 * @return String whole line in response or null if invalid index or running of command fails
+	 */
+	public static String getAnswerAt(String cmd2launch, int answerIdx) {
+		ArrayList<String> sa = ExecutingCommand.runNative(cmd2launch);
+
+		if (sa != null && answerIdx >= 0 && answerIdx < sa.size())
+			return sa.get(answerIdx);
 		else
 			return null;
 	}


### PR DESCRIPTION
Squashed commit:

[f8d2589] Code altered to suit more existing codebase (error management), added english localization flag to wmic command to prevent problems with parsing on non-english localized machines

[890ad66] CPU load implementation for windows

[39b933f] Added ability to read different than just first result line from command output (with proper sanitization) (+1 squashed commits)