### PR TITLE
Use sysinfo for linux total memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Next
 * [#15](https://github.com/dblock/oshi/pull/15), [#18](https://github.com/dblock/oshi/pull/18): Added support for CPU load - [@kamenitxan](https://github.com/kamenitxan), [@Sorceror](https://github.com/Sorceror).
 * [#25](https://github.com/dblock/oshi/pull/25): Include inactive memory amount in GlobalMemory#getAvailable on Mac/Linux - [@dbwiddis](https://github.com/dbwiddis).
 * [#27](https://github.com/dblock/oshi/pull/27): Replace all Mac OS X command line parsing with JNA or System properties - [@dbwiddis](https://github.com/dbwiddis).
+* [#29](https://github.com/dblock/oshi/pull/29): Replace Linux totalMemory calculation with JNA and revised MemAvailable backup - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here.
 
 

--- a/src/main/java/oshi/hardware/HardwareAbstractionLayer.java
+++ b/src/main/java/oshi/hardware/HardwareAbstractionLayer.java
@@ -9,21 +9,22 @@ package oshi.hardware;
 
 /**
  * A hardware abstraction layer.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public interface HardwareAbstractionLayer {
 
 	/**
 	 * Get CPUs.
-	 * @return
-	 *  An array of Processor objects.
+	 * 
+	 * @return An array of Processor objects.
 	 */
 	Processor[] getProcessors();
-	
+
 	/**
 	 * Get Memory information.
-	 * @return
-	 *  A memory object.
+	 * 
+	 * @return A memory object.
 	 */
 	Memory getMemory();
 

--- a/src/main/java/oshi/hardware/Memory.java
+++ b/src/main/java/oshi/hardware/Memory.java
@@ -8,24 +8,27 @@
 package oshi.hardware;
 
 /**
- * Memory refers to the state information of a computing system, as it is kept active in some physical 
- * structure. The term "memory" is used for the information in physical systems which are fast (ie. RAM),
- * as a distinction from physical systems which are slow to access (ie. data storage). By design, the term
- * "memory" refers to temporary state devices, whereas the term "storage" is reserved for permanent data.
+ * Memory refers to the state information of a computing system, as it is kept
+ * active in some physical structure. The term "memory" is used for the
+ * information in physical systems which are fast (ie. RAM), as a distinction
+ * from physical systems which are slow to access (ie. data storage). By design,
+ * the term "memory" refers to temporary state devices, whereas the term
+ * "storage" is reserved for permanent data.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public interface Memory {
 	/**
 	 * Total memory.
-	 * @return
-	 *  Total number of bytes.
+	 * 
+	 * @return Total number of bytes.
 	 */
 	long getTotal();
-	
+
 	/**
 	 * Currently available.
-	 * @return
-	 *  Available number of bytes.
+	 * 
+	 * @return Available number of bytes.
 	 */
 	long getAvailable();
 }

--- a/src/main/java/oshi/hardware/Processor.java
+++ b/src/main/java/oshi/hardware/Processor.java
@@ -8,58 +8,70 @@
 package oshi.hardware;
 
 /**
- * The Central Processing Unit (CPU) or the processor is the portion of a computer system that carries 
- * out the instructions of a computer program, and is the primary element carrying out the computer's 
- * functions.
+ * The Central Processing Unit (CPU) or the processor is the portion of a
+ * computer system that carries out the instructions of a computer program, and
+ * is the primary element carrying out the computer's functions.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public interface Processor {
 	/**
 	 * Processor vendor.
-	 * @return
-	 *  String.
+	 * 
+	 * @return String.
 	 */
 	String getVendor();
 
 	/**
 	 * Set processor vendor.
-	 * @param vendor Vendor.
+	 * 
+	 * @param vendor
+	 *            Vendor.
 	 */
 	void setVendor(String vendor);
 
 	/**
 	 * Name, eg. Intel(R) Core(TM)2 Duo CPU T7300 @ 2.00GHz
+	 * 
 	 * @return Processor name.
 	 */
 	String getName();
 
 	/**
 	 * Set processor name.
-	 * @param name Name.
+	 * 
+	 * @param name
+	 *            Name.
 	 */
 	void setName(String name);
 
 	/**
 	 * Identifier, eg. x86 Family 6 Model 15 Stepping 10.
+	 * 
 	 * @return Processor identifier.
 	 */
 	String getIdentifier();
 
 	/**
 	 * Set processor identifier.
-	 * @param identifier Identifier.
+	 * 
+	 * @param identifier
+	 *            Identifier.
 	 */
 	void setIdentifier(String identifier);
 
 	/**
 	 * Is CPU 64bit?
+	 * 
 	 * @return True if cpu is 64bit.
 	 */
 	boolean isCpu64bit();
 
 	/**
 	 * Set flag is cpu is 64bit.
-	 * @param cpu64 True if cpu is 64.
+	 * 
+	 * @param cpu64
+	 *            True if cpu is 64.
 	 */
 	void setCpu64(boolean cpu64);
 
@@ -69,7 +81,8 @@ public interface Processor {
 	String getStepping();
 
 	/**
-	 * @param _stepping the _stepping to set
+	 * @param _stepping
+	 *            the _stepping to set
 	 */
 	void setStepping(String _stepping);
 
@@ -79,7 +92,8 @@ public interface Processor {
 	String getModel();
 
 	/**
-	 * @param _model the _model to set
+	 * @param _model
+	 *            the _model to set
 	 */
 	void setModel(String _model);
 
@@ -89,12 +103,14 @@ public interface Processor {
 	String getFamily();
 
 	/**
-	 * @param _family the _family to set
+	 * @param _family
+	 *            the _family to set
 	 */
 	void setFamily(String _family);
 
 	/**
 	 * Get total CPU load
+	 * 
 	 * @return CPU load in %
 	 */
 	float getLoad();

--- a/src/main/java/oshi/software/os/OperatingSystem.java
+++ b/src/main/java/oshi/software/os/OperatingSystem.java
@@ -8,30 +8,32 @@
 package oshi.software.os;
 
 /**
- * An operating system (OS) is the software on a computer that manages the way different programs 
- * use its hardware, and regulates the ways that a user controls the computer.
+ * An operating system (OS) is the software on a computer that manages the way
+ * different programs use its hardware, and regulates the ways that a user
+ * controls the computer.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public interface OperatingSystem {
-	
+
 	/**
 	 * Operating system family.
-	 * @return
-	 *  String.
+	 * 
+	 * @return String.
 	 */
 	public String getFamily();
-	
+
 	/**
 	 * Manufacturer.
-	 * @return
-	 *  String.
+	 * 
+	 * @return String.
 	 */
 	public String getManufacturer();
 
 	/**
 	 * Operating system version.
-	 * @return
-	 *  Version.
+	 * 
+	 * @return Version.
 	 */
 	OperatingSystemVersion getVersion();
 }

--- a/src/main/java/oshi/software/os/OperatingSystemVersion.java
+++ b/src/main/java/oshi/software/os/OperatingSystemVersion.java
@@ -9,8 +9,9 @@ package oshi.software.os;
 
 /**
  * Version of an operating system.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public interface OperatingSystemVersion {
-	
+
 }

--- a/src/main/java/oshi/software/os/Process.java
+++ b/src/main/java/oshi/software/os/Process.java
@@ -8,9 +8,11 @@
 package oshi.software.os;
 
 /**
- * A process is an instance of a computer program that is being executed. It contains the program code
- * and its current activity. Depending on the operating system (OS), a process may be made up of multiple
- * threads of execution that execute instructions concurrently.
+ * A process is an instance of a computer program that is being executed. It
+ * contains the program code and its current activity. Depending on the
+ * operating system (OS), a process may be made up of multiple threads of
+ * execution that execute instructions concurrently.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public interface Process {

--- a/src/main/java/oshi/software/os/linux/Libc.java
+++ b/src/main/java/oshi/software/os/linux/Libc.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Daniel Widdis, 2015
+ * widdis[at]gmail[dot]com
+ * All Rights Reserved
+ * Eclipse Public License (EPLv1)
+ * http://oshi.codeplex.com/license
+ */
+package oshi.software.os.linux;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Structure;
+
+public interface Libc extends Library {
+
+	public static final Libc INSTANCE = (Libc) Native.loadLibrary("c",
+			Libc.class);
+
+	public static final class Sysinfo extends Structure {
+		public NativeLong uptime; // Seconds since boot
+		// 1, 5, and 15 minute load averages
+		public NativeLong[] loads = new NativeLong[3];
+		public NativeLong totalram; // Total usable main memory size
+		public NativeLong freeram; // Available memory size
+		public NativeLong sharedram; // Amount of shared memory
+		public NativeLong bufferram; // Memory used by buffers
+		public NativeLong totalswap; // Total swap space size
+		public NativeLong freeswap; // swap space still available
+		public short procs; // Number of current processes
+		public NativeLong totalhigh; // Total high memory size
+		public NativeLong freehigh; // Available high memory size
+		public int mem_unit; // Memory unit size in bytes
+		public byte[] _f = new byte[8]; // Won't be written for 64-bit systems
+	}
+
+	int sysinfo(Sysinfo info);
+
+}

--- a/src/main/java/oshi/software/os/linux/LinuxHardwareAbstractionLayer.java
+++ b/src/main/java/oshi/software/os/linux/LinuxHardwareAbstractionLayer.java
@@ -1,16 +1,15 @@
 package oshi.software.os.linux;
 
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Scanner;
 
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.Memory;
 import oshi.hardware.Processor;
 import oshi.software.os.linux.proc.CentralProcessor;
 import oshi.software.os.linux.proc.GlobalMemory;
+import oshi.util.FileUtil;
 
 /**
  * @author alessandro[at]perucchi[dot]org
@@ -33,18 +32,16 @@ public class LinuxHardwareAbstractionLayer implements HardwareAbstractionLayer {
 
 		if (_processors == null) {
 			List<Processor> processors = new ArrayList<Processor>();
-			Scanner in = null;
+			List<String> cpuInfo = null;
 			try {
-				in = new Scanner(new FileReader("/proc/cpuinfo"));
-			} catch (FileNotFoundException e) {
+				cpuInfo = FileUtil.readFile("/proc/cpuinfo");
+			} catch (IOException e) {
 				System.err.println("Problem with: /proc/cpuinfo");
 				System.err.println(e.getMessage());
 				return null;
 			}
-			in.useDelimiter("\n");
 			CentralProcessor cpu = null;
-			while (in.hasNext()) {
-				String toBeAnalyzed = in.next();
+			for (String toBeAnalyzed : cpuInfo) {
 				if (toBeAnalyzed.equals("")) {
 					if (cpu != null) {
 						processors.add(cpu);
@@ -93,7 +90,6 @@ public class LinuxHardwareAbstractionLayer implements HardwareAbstractionLayer {
 					continue;
 				}
 			}
-			in.close();
 			if (cpu != null) {
 				processors.add(cpu);
 			}

--- a/src/main/java/oshi/software/os/linux/LinuxHardwareAbstractionLayer.java
+++ b/src/main/java/oshi/software/os/linux/LinuxHardwareAbstractionLayer.java
@@ -61,11 +61,12 @@ public class LinuxHardwareAbstractionLayer implements HardwareAbstractionLayer {
 					continue;
 				}
 				if (toBeAnalyzed.startsWith("flags\t")) {
-					String[] flags=toBeAnalyzed.split(SEPARATOR)[1].split(" ");
-					boolean found=false;
-					for (String flag: flags) {
+					String[] flags = toBeAnalyzed.split(SEPARATOR)[1]
+							.split(" ");
+					boolean found = false;
+					for (String flag : flags) {
 						if (flag.equalsIgnoreCase("LM")) {
-							found=true;
+							found = true;
 							break;
 						}
 					}
@@ -74,7 +75,7 @@ public class LinuxHardwareAbstractionLayer implements HardwareAbstractionLayer {
 				}
 				if (toBeAnalyzed.startsWith("cpu family\t")) {
 					cpu.setFamily(toBeAnalyzed.split(SEPARATOR)[1]); // model
-																	// name
+																		// name
 					continue;
 				}
 				if (toBeAnalyzed.startsWith("model\t")) {
@@ -84,7 +85,7 @@ public class LinuxHardwareAbstractionLayer implements HardwareAbstractionLayer {
 				}
 				if (toBeAnalyzed.startsWith("stepping\t")) {
 					cpu.setStepping(toBeAnalyzed.split(SEPARATOR)[1]); // model
-																	// name
+																		// name
 					continue;
 				}
 				if (toBeAnalyzed.startsWith("vendor_id")) {

--- a/src/main/java/oshi/software/os/linux/proc/CentralProcessor.java
+++ b/src/main/java/oshi/software/os/linux/proc/CentralProcessor.java
@@ -7,13 +7,13 @@
  */
 package oshi.software.os.linux.proc;
 
-import oshi.hardware.Processor;
-import oshi.util.FormatUtil;
-
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Scanner;
+
+import oshi.hardware.Processor;
+import oshi.util.FormatUtil;
 
 /**
  * A CPU as defined in Linux /proc.
@@ -184,8 +184,10 @@ public class CentralProcessor implements Processor {
 				loads.add(Float.valueOf(load));
 			}
 		}
-		// ((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal) - see http://stackoverflow.com/a/23376195/4359897
-		float totalCpuLoad = (loads.get(0) + loads.get(2))*100 / (loads.get(0) + loads.get(2) + loads.get(3));
+		// ((Total-PrevTotal)-(Idle-PrevIdle))/(Total-PrevTotal) - see
+		// http://stackoverflow.com/a/23376195/4359897
+		float totalCpuLoad = (loads.get(0) + loads.get(2)) * 100
+				/ (loads.get(0) + loads.get(2) + loads.get(3));
 		return FormatUtil.round(totalCpuLoad, 2);
 	}
 

--- a/src/main/java/oshi/software/os/linux/proc/CentralProcessor.java
+++ b/src/main/java/oshi/software/os/linux/proc/CentralProcessor.java
@@ -178,6 +178,7 @@ public class CentralProcessor implements Processor {
 		}
 		in.useDelimiter("\n");
 		String[] result = in.next().split(" ");
+		in.close();
 		ArrayList<Float> loads = new ArrayList<Float>();
 		for (String load : result) {
 			if (load.matches("-?\\d+(\\.\\d+)?")) {

--- a/src/main/java/oshi/software/os/linux/proc/GlobalMemory.java
+++ b/src/main/java/oshi/software/os/linux/proc/GlobalMemory.java
@@ -1,73 +1,82 @@
 /**
  * Copyright (c) Alessandro Perucchi, 2014
  * alessandro[at]perucchi[dot]org
+ * Daniel Widdis, 2015
+ * widdis[at]gmail[dot]com
  * All Rights Reserved
  * Eclipse Public License (EPLv1)
  * http://oshi.codeplex.com/license
  */
 package oshi.software.os.linux.proc;
 
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.util.Scanner;
+import java.io.IOException;
+import java.util.List;
 
 import oshi.hardware.Memory;
+import oshi.software.os.linux.Libc;
+import oshi.software.os.linux.Libc.Sysinfo;
+import oshi.util.FileUtil;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Native;
 
 /**
- * Memory obtained by /proc/meminfo.
+ * Memory obtained by /proc/meminfo and sysinfo.totalram
  * 
  * @author alessandro[at]perucchi[dot]org
+ * @author widdis[at]gmail[dot]com
  */
 public class GlobalMemory implements Memory {
 
 	private long totalMemory = 0;
 
 	public long getAvailable() {
-		long returnCurrentUsageMemory = 0;
-		Scanner in = null;
+		long availableMemory = 0;
+		List<String> memInfo = null;
 		try {
-			in = new Scanner(new FileReader("/proc/meminfo"));
-		} catch (FileNotFoundException e) {
-			return returnCurrentUsageMemory;
+			memInfo = FileUtil.readFile("/proc/meminfo");
+		} catch (IOException e) {
+			System.err.println("Problem with: /proc/meminfo");
+			System.err.println(e.getMessage());
+			return availableMemory;
 		}
-		in.useDelimiter("\n");
-		while (in.hasNext()) {
-			String checkLine = in.next();
+		for (String checkLine : memInfo) {
+			// If we have MemAvailable, it trumps all. See code in
+			// https://git.kernel.org/cgit/linux/kernel/git/torvalds/
+			// linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
 			if (checkLine.startsWith("MemAvailable:")) {
 				String[] memorySplit = checkLine.split("\\s+");
-				returnCurrentUsageMemory = parseMeminfo(memorySplit);
+				availableMemory = parseMeminfo(memorySplit);
 				break;
-			} else if (checkLine.startsWith("MemFree:")) {
+			} else
+			// Otherwise we combine MemFree + Active(file), Inactive(file), and
+			// SReclaimable. Free+cached is no longer appropriate. MemAvailable
+			// reduces these values using watermarks to estimate when swapping
+			// is prevented, omitted here for simplicity (assuming 0 swap).
+			if (checkLine.startsWith("MemFree:")) {
 				String[] memorySplit = checkLine.split("\\s+");
-				returnCurrentUsageMemory += parseMeminfo(memorySplit);
-			} else if (checkLine.startsWith("Inactive:")) {
+				availableMemory += parseMeminfo(memorySplit);
+			} else if (checkLine.startsWith("Active(file):")) {
 				String[] memorySplit = checkLine.split("\\s+");
-				returnCurrentUsageMemory += parseMeminfo(memorySplit);
+				availableMemory += parseMeminfo(memorySplit);
+			} else if (checkLine.startsWith("Inactive(file):")) {
+				String[] memorySplit = checkLine.split("\\s+");
+				availableMemory += parseMeminfo(memorySplit);
+			} else if (checkLine.startsWith("SReclaimable:")) {
+				String[] memorySplit = checkLine.split("\\s+");
+				availableMemory += parseMeminfo(memorySplit);
 			}
 		}
-		in.close();
-		return returnCurrentUsageMemory;
+		return availableMemory;
 	}
 
 	public long getTotal() {
 		if (totalMemory == 0) {
-			Scanner in = null;
-			try {
-				in = new Scanner(new FileReader("/proc/meminfo"));
-			} catch (FileNotFoundException e) {
-				totalMemory = 0;
-				return totalMemory;
-			}
-			in.useDelimiter("\n");
-			while (in.hasNext()) {
-				String checkLine = in.next();
-				if (checkLine.startsWith("MemTotal:")) {
-					String[] memorySplit = checkLine.split("\\s+");
-					totalMemory = parseMeminfo(memorySplit);
-					break;
-				}
-			}
-			in.close();
+			Sysinfo info = new Sysinfo();
+			if (0 != Libc.INSTANCE.sysinfo(info))
+				throw new LastErrorException("Error code: "
+						+ Native.getLastError());
+			totalMemory = info.totalram.longValue() * info.mem_unit;
 		}
 		return totalMemory;
 	}

--- a/src/main/java/oshi/software/os/mac/local/GlobalMemory.java
+++ b/src/main/java/oshi/software/os/mac/local/GlobalMemory.java
@@ -23,6 +23,8 @@ import com.sun.jna.ptr.LongByReference;
  */
 public class GlobalMemory implements Memory {
 
+	long totalMemory = 0;
+
 	public long getAvailable() {
 		long availableMemory = 0;
 		long pageSize = 4096;
@@ -46,13 +48,15 @@ public class GlobalMemory implements Memory {
 	}
 
 	public long getTotal() {
-		long totalMemory = 0;
-		int[] mib = { SystemB.CTL_HW, SystemB.HW_MEMSIZE };
-		Pointer pMemSize = new com.sun.jna.Memory(SystemB.UINT64_SIZE);
-		if (0 != SystemB.INSTANCE.sysctl(mib, mib.length, pMemSize,
-				new IntByReference(SystemB.UINT64_SIZE), null, 0))
-			throw new LastErrorException("Error code: " + Native.getLastError());
-		totalMemory = pMemSize.getLong(0);
+		if (totalMemory == 0) {
+			int[] mib = { SystemB.CTL_HW, SystemB.HW_MEMSIZE };
+			Pointer pMemSize = new com.sun.jna.Memory(SystemB.UINT64_SIZE);
+			if (0 != SystemB.INSTANCE.sysctl(mib, mib.length, pMemSize,
+					new IntByReference(SystemB.UINT64_SIZE), null, 0))
+				throw new LastErrorException("Error code: "
+						+ Native.getLastError());
+			totalMemory = pMemSize.getLong(0);
+		}
 		return totalMemory;
 	}
 }

--- a/src/main/java/oshi/software/os/windows/WindowsHardwareAbstractionLayer.java
+++ b/src/main/java/oshi/software/os/windows/WindowsHardwareAbstractionLayer.java
@@ -13,11 +13,12 @@ import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.WinReg;
 import oshi.util.ExecutingCommand;
 
-public class WindowsHardwareAbstractionLayer implements HardwareAbstractionLayer {
+public class WindowsHardwareAbstractionLayer implements
+		HardwareAbstractionLayer {
 
 	private Processor[] _processors = null;
 	private Memory _memory = null;
-	
+
 	public Memory getMemory() {
 		if (_memory == null) {
 			_memory = new GlobalMemory();
@@ -26,25 +27,29 @@ public class WindowsHardwareAbstractionLayer implements HardwareAbstractionLayer
 	}
 
 	public Processor[] getProcessors() {
-		
+
 		if (_processors == null) {
 			final String cpuRegistryRoot = "HARDWARE\\DESCRIPTION\\System\\CentralProcessor";
 			List<Processor> processors = new ArrayList<Processor>();
-			String[] processorIds = Advapi32Util.registryGetKeys(WinReg.HKEY_LOCAL_MACHINE, cpuRegistryRoot);
-			for(String processorId : processorIds) {
-				String cpuRegistryPath = cpuRegistryRoot + "\\" + processorId; 
+			String[] processorIds = Advapi32Util.registryGetKeys(
+					WinReg.HKEY_LOCAL_MACHINE, cpuRegistryRoot);
+			for (String processorId : processorIds) {
+				String cpuRegistryPath = cpuRegistryRoot + "\\" + processorId;
 				CentralProcessor cpu = new CentralProcessor();
-				cpu.setIdentifier(Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, 
-						cpuRegistryPath, "Identifier"));
-				cpu.setName(Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, 
-						cpuRegistryPath, "ProcessorNameString"));
-				cpu.setVendor(Advapi32Util.registryGetStringValue(WinReg.HKEY_LOCAL_MACHINE, 
-						cpuRegistryPath, "VendorIdentifier"));
+				cpu.setIdentifier(Advapi32Util.registryGetStringValue(
+						WinReg.HKEY_LOCAL_MACHINE, cpuRegistryPath,
+						"Identifier"));
+				cpu.setName(Advapi32Util.registryGetStringValue(
+						WinReg.HKEY_LOCAL_MACHINE, cpuRegistryPath,
+						"ProcessorNameString"));
+				cpu.setVendor(Advapi32Util.registryGetStringValue(
+						WinReg.HKEY_LOCAL_MACHINE, cpuRegistryPath,
+						"VendorIdentifier"));
 				processors.add(cpu);
-			}			
+			}
 			_processors = processors.toArray(new Processor[0]);
 		}
-		
+
 		return _processors;
 	}
 

--- a/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
+++ b/src/main/java/oshi/software/os/windows/WindowsOperatingSystem.java
@@ -12,18 +12,19 @@ import oshi.software.os.OperatingSystemVersion;
 import oshi.software.os.windows.nt.OSVersionInfoEx;
 
 /**
- * Microsoft Windows is a family of proprietary operating systems most commonly used on
- * personal computers.
+ * Microsoft Windows is a family of proprietary operating systems most commonly
+ * used on personal computers.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public class WindowsOperatingSystem implements OperatingSystem {
-	
+
 	private OperatingSystemVersion _version = null;
-	
+
 	public OperatingSystemVersion getVersion() {
 		if (_version == null) {
 			_version = new OSVersionInfoEx();
-		}		
+		}
 		return _version;
 	}
 
@@ -34,7 +35,7 @@ public class WindowsOperatingSystem implements OperatingSystem {
 	public String getManufacturer() {
 		return "Microsoft";
 	}
-	
+
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(getManufacturer());

--- a/src/main/java/oshi/software/os/windows/nt/CentralProcessor.java
+++ b/src/main/java/oshi/software/os/windows/nt/CentralProcessor.java
@@ -12,30 +12,32 @@ import oshi.util.ExecutingCommand;
 
 /**
  * A CPU as defined in Windows registry.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public class CentralProcessor implements Processor {
 	private String _vendor;
 	private String _name;
 	private String _identifier;
-	
+
 	public CentralProcessor() {
-		
+
 	}
-	
+
 	/**
 	 * Vendor identifier, eg. GenuineIntel.
-	 * @return
-	 *  Processor vendor. 
+	 * 
+	 * @return Processor vendor.
 	 */
 	public String getVendor() {
 		return _vendor;
 	}
-	
+
 	/**
 	 * Set processor vendor.
+	 * 
 	 * @param vendor
-	 *  Vendor.
+	 *            Vendor.
 	 */
 	public void setVendor(String vendor) {
 		_vendor = vendor;
@@ -43,35 +45,37 @@ public class CentralProcessor implements Processor {
 
 	/**
 	 * Name, eg. Intel(R) Core(TM)2 Duo CPU T7300 @ 2.00GHz
-	 * @return
-	 *  Processor name. 
+	 * 
+	 * @return Processor name.
 	 */
 	public String getName() {
 		return _name;
 	}
-	
+
 	/**
 	 * Set processor name.
+	 * 
 	 * @param name
-	 *  Name.
+	 *            Name.
 	 */
 	public void setName(String name) {
 		_name = name;
 	}
-	
+
 	/**
 	 * Identifier, eg. x86 Family 6 Model 15 Stepping 10.
-	 * @return
-	 *  Processor identifier. 
+	 * 
+	 * @return Processor identifier.
 	 */
 	public String getIdentifier() {
 		return _identifier;
 	}
-	
+
 	/**
 	 * Set processor identifier.
+	 * 
 	 * @param identifier
-	 *  Identifier.
+	 *            Identifier.
 	 */
 	public void setIdentifier(String identifier) {
 		_identifier = identifier;
@@ -138,17 +142,20 @@ public class CentralProcessor implements Processor {
 	 */
 	public float getLoad() {
 		// this always return whole number value on windows machines
-		String result = ExecutingCommand.getAnswerAt("wmic /locale:ms_409 cpu get loadpercentage", 2);
+		String result = ExecutingCommand.getAnswerAt(
+				"wmic /locale:ms_409 cpu get loadpercentage", 2);
 
 		if (result == null || result.isEmpty()) {
-			throw new RuntimeException("CPU load could not be obtained from system");
+			throw new RuntimeException(
+					"CPU load could not be obtained from system");
 		}
 
 		try {
 			return Integer.valueOf(result.trim());
 		} catch (NumberFormatException e) {
 			System.err.println("Cannot parse CPU load value: " + result.trim());
-			throw new RuntimeException("Cannot parse load value: " + result.trim());
+			throw new RuntimeException("Cannot parse load value: "
+					+ result.trim());
 		}
 	}
 

--- a/src/main/java/oshi/software/os/windows/nt/GlobalMemory.java
+++ b/src/main/java/oshi/software/os/windows/nt/GlobalMemory.java
@@ -15,17 +15,18 @@ import com.sun.jna.platform.win32.WinBase.MEMORYSTATUSEX;
 
 /**
  * Memory obtained by GlobalMemoryStatusEx.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public class GlobalMemory implements Memory {
 	MEMORYSTATUSEX _memory = new MEMORYSTATUSEX();
 
 	public GlobalMemory() {
-    	if (! Kernel32.INSTANCE.GlobalMemoryStatusEx(_memory)) {
-    		throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-    	}
+		if (!Kernel32.INSTANCE.GlobalMemoryStatusEx(_memory)) {
+			throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+		}
 	}
-	
+
 	public long getAvailable() {
 		return _memory.ullAvailPhys.longValue();
 	}

--- a/src/main/java/oshi/software/os/windows/nt/OSNativeSystemInfo.java
+++ b/src/main/java/oshi/software/os/windows/nt/OSNativeSystemInfo.java
@@ -14,39 +14,40 @@ import com.sun.jna.ptr.IntByReference;
 
 /**
  * Windows OS native system information.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public class OSNativeSystemInfo {
 	private SYSTEM_INFO _si = null;
 
 	public OSNativeSystemInfo() {
-		
+
 		SYSTEM_INFO si = new SYSTEM_INFO();
 		Kernel32.INSTANCE.GetSystemInfo(si);
-    	
+
 		try {
 			IntByReference isWow64 = new IntByReference();
-	    	HANDLE hProcess = Kernel32.INSTANCE.GetCurrentProcess();
-	    	if (Kernel32.INSTANCE.IsWow64Process(hProcess, isWow64)) {
-	    		if (isWow64.getValue() > 0) {
-	    			Kernel32.INSTANCE.GetNativeSystemInfo(si);
-	    		}
-	    	}
-		} catch(UnsatisfiedLinkError e) {
+			HANDLE hProcess = Kernel32.INSTANCE.GetCurrentProcess();
+			if (Kernel32.INSTANCE.IsWow64Process(hProcess, isWow64)) {
+				if (isWow64.getValue() > 0) {
+					Kernel32.INSTANCE.GetNativeSystemInfo(si);
+				}
+			}
+		} catch (UnsatisfiedLinkError e) {
 			// no WOW64 support
 		}
-    	
-    	_si = si;
+
+		_si = si;
 	}
-	
+
 	public OSNativeSystemInfo(SYSTEM_INFO si) {
 		_si = si;
 	}
-	
+
 	/**
 	 * Number of processors.
-	 * @return
-	 *  Integer.
+	 * 
+	 * @return Integer.
 	 */
 	public int getNumberOfProcessors() {
 		return _si.dwNumberOfProcessors.intValue();

--- a/src/main/java/oshi/software/os/windows/nt/OSVersionInfoEx.java
+++ b/src/main/java/oshi/software/os/windows/nt/OSVersionInfoEx.java
@@ -20,263 +20,222 @@ import com.sun.jna.platform.win32.WinReg;
 import com.sun.jna.platform.win32.WinUser;
 
 /**
- * Contains operating system version information. The information includes major and
- * minor version numbers, a build number, a platform identifier, and descriptive text
- * about the operating system.
+ * Contains operating system version information. The information includes major
+ * and minor version numbers, a build number, a platform identifier, and
+ * descriptive text about the operating system.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public class OSVersionInfoEx implements OperatingSystemVersion {
-    private OSVERSIONINFOEX _versionInfo;
+	private OSVERSIONINFOEX _versionInfo;
 
-    public OSVersionInfoEx() {
-        _versionInfo = new OSVERSIONINFOEX();
-        if (!Kernel32.INSTANCE.GetVersionEx(_versionInfo)) {
-            throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
-        }
-    }
+	public OSVersionInfoEx() {
+		_versionInfo = new OSVERSIONINFOEX();
+		if (!Kernel32.INSTANCE.GetVersionEx(_versionInfo)) {
+			throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
+		}
+	}
 
-    /**
-     * The major version number of the operating system.
-     * @return
-     *         The major version within the following supported operating systems.
-     *         Windows 8: 6.2
-     *         Windows Server 2012: 6.2
-     *         Windows 7: 6.1
-     *         Windows Server 2008 R2: 6.1
-     *         Windows Server 2008: 6.0
-     *         Windows Vista: 6.0
-     *         Windows Server 2003 R2: 5.2
-     *         Windows Home Server: 5.2
-     *         Windows Server 2003: 5.2
-     *         Windows XP Professional x64 Edition: 5.2
-     *         Windows XP: 5.1
-     *         Windows 2000: 5.0
-     */
-    public int getMajor() {
-        return _versionInfo.dwMajorVersion.intValue();
-    }
+	/**
+	 * The major version number of the operating system.
+	 * 
+	 * @return The major version within the following supported operating
+	 *         systems. Windows 8: 6.2 Windows Server 2012: 6.2 Windows 7: 6.1
+	 *         Windows Server 2008 R2: 6.1 Windows Server 2008: 6.0 Windows
+	 *         Vista: 6.0 Windows Server 2003 R2: 5.2 Windows Home Server: 5.2
+	 *         Windows Server 2003: 5.2 Windows XP Professional x64 Edition: 5.2
+	 *         Windows XP: 5.1 Windows 2000: 5.0
+	 */
+	public int getMajor() {
+		return _versionInfo.dwMajorVersion.intValue();
+	}
 
-    /**
-     * The minor version number of the operating system.
-     * @return
-     *         The minor version within the following supported operating systems.
-     *         Windows 8: 6.2
-     *         Windows Server 2012: 6.2
-     *         Windows 7: 6.1
-     *         Windows Server 2008 R2: 6.1
-     *         Windows Server 2008: 6.0
-     *         Windows Vista: 6.0
-     *         Windows Server 2003 R2: 5.2
-     *         Windows Home Server: 5.2
-     *         Windows Server 2003: 5.2
-     *         Windows XP Professional x64 Edition: 5.2
-     *         Windows XP: 5.1
-     *         Windows 2000: 5.0
-     */
-    public int getMinor() {
-        return _versionInfo.dwMinorVersion.intValue();
-    }
+	/**
+	 * The minor version number of the operating system.
+	 * 
+	 * @return The minor version within the following supported operating
+	 *         systems. Windows 8: 6.2 Windows Server 2012: 6.2 Windows 7: 6.1
+	 *         Windows Server 2008 R2: 6.1 Windows Server 2008: 6.0 Windows
+	 *         Vista: 6.0 Windows Server 2003 R2: 5.2 Windows Home Server: 5.2
+	 *         Windows Server 2003: 5.2 Windows XP Professional x64 Edition: 5.2
+	 *         Windows XP: 5.1 Windows 2000: 5.0
+	 */
+	public int getMinor() {
+		return _versionInfo.dwMinorVersion.intValue();
+	}
 
-    /**
-     * The build number of the operating system.
-     * @return
-     *         Build number.
-     */
-    public int getBuildNumber() {
-        return _versionInfo.dwBuildNumber.intValue();
-    }
+	/**
+	 * The build number of the operating system.
+	 * 
+	 * @return Build number.
+	 */
+	public int getBuildNumber() {
+		return _versionInfo.dwBuildNumber.intValue();
+	}
 
-    /**
-     * The operating system platform. This member can be VER_PLATFORM_WIN32_NT.
-     * @return
-     *         Platform ID.
-     */
-    public int getPlatformId() {
-        return _versionInfo.dwPlatformId.intValue();
-    }
+	/**
+	 * The operating system platform. This member can be VER_PLATFORM_WIN32_NT.
+	 * 
+	 * @return Platform ID.
+	 */
+	public int getPlatformId() {
+		return _versionInfo.dwPlatformId.intValue();
+	}
 
-    /**
-     * String, such as "Service Pack 3", that indicates the latest Service Pack installed on
-     * the system. If no Service Pack has been installed, the string is empty.
-     * @return
-     *         Service pack.
-     */
-    public String getServicePack() {
-        return Native.toString(_versionInfo.szCSDVersion);
-    }
+	/**
+	 * String, such as "Service Pack 3", that indicates the latest Service Pack
+	 * installed on the system. If no Service Pack has been installed, the
+	 * string is empty.
+	 * 
+	 * @return Service pack.
+	 */
+	public String getServicePack() {
+		return Native.toString(_versionInfo.szCSDVersion);
+	}
 
-    /**
-     * A bit mask that identifies the product suites available on the system.
-     * @return
-     *         Suite mask.
-     */
-    public int getSuiteMask() {
-        return _versionInfo.wSuiteMask.intValue();
-    }
+	/**
+	 * A bit mask that identifies the product suites available on the system.
+	 * 
+	 * @return Suite mask.
+	 */
+	public int getSuiteMask() {
+		return _versionInfo.wSuiteMask.intValue();
+	}
 
-    /**
-     * Any additional information about the system.
-     * @return
-     *         Product type.
-     */
-    public byte getProductType() {
-        return _versionInfo.wProductType;
-    }
+	/**
+	 * Any additional information about the system.
+	 * 
+	 * @return Product type.
+	 */
+	public byte getProductType() {
+		return _versionInfo.wProductType;
+	}
 
-    @Override
-    public String toString() {
-        String version = null;
+	@Override
+	public String toString() {
+		String version = null;
 
-        // see http://msdn.microsoft.com/en-us/library/windows/desktop/ms724833%28v=vs.85%29.aspx
-        if (getPlatformId() == WinNT.VER_PLATFORM_WIN32_NT) {
-        	// 8.1
-            if (getMajor() == 6
-                    && getMinor() == 3
-                    && getProductType() == WinNT.VER_NT_WORKSTATION)
-            {
-                version = "8.1";
-            }
-            // Server 2008 R2
-            else if (getMajor() == 6
-                    && getMinor() == 3
-                    && getProductType() != WinNT.VER_NT_WORKSTATION)
-            {
-                version = "Server 2012 R2";
-            }
-            // 8
-            else if (getMajor() == 6
-                    && getMinor() == 2
-                    && getProductType() == WinNT.VER_NT_WORKSTATION)
-            {
-                version = "8";
-            }
-            // Server 2008
-            else if (getMajor() == 6
-                    && getMinor() == 2
-                    && getProductType() != WinNT.VER_NT_WORKSTATION)
-            {
-                version = "Server 2012";
-            }
-            // 7
-            else if (getMajor() == 6
-                    && getMinor() == 1
-                    && getProductType() == WinNT.VER_NT_WORKSTATION)
-            {
-                version = "7";
-            }
-            // Server 2008 R2
-            else if (getMajor() == 6
-                    && getMinor() == 1
-                    && getProductType() != WinNT.VER_NT_WORKSTATION)
-            {
-                version = "Server 2008 R2";
-            }
-            // Server 2008
-            else if (getMajor() == 6
-                    && getMinor() == 0
-                    && getProductType() != WinNT.VER_NT_WORKSTATION)
-            {
-                version = "Server 2008";
-            }
-            // Vista
-            else if (getMajor() == 6
-                    && getMinor() == 0
-                    && getProductType() == WinNT.VER_NT_WORKSTATION)
-            {
-                version = "Vista";
-            }
-            // Server 2003
-            else if (getMajor() == 5
-                    && getMinor() == 2
-                    && getProductType() != WinNT.VER_NT_WORKSTATION
-                    && User32.INSTANCE.GetSystemMetrics(WinUser.SM_SERVERR2) != 0)
-            {
-                version = "Server 2003";
-            }
-            // Server 2003 R2
-            else if (getMajor() == 5
-                    && getMinor() == 2
-                    && getProductType() != WinNT.VER_NT_WORKSTATION
-                    && User32.INSTANCE.GetSystemMetrics(WinUser.SM_SERVERR2) == 0)
-            {
-                version = "Server 2003 R2";
-            }
-            // XP 64 bit
-            else if (getMajor() == 5
-                    && getMinor() == 2
-                    && getProductType() == WinNT.VER_NT_WORKSTATION)
-            {
-                version = "XP";
-            }
-            // XP 32 bit
-            else if (getMajor() == 5
-                    && getMinor() == 1)
-            {
-                version = "XP";
-            }
-            // 2000
-            else if (getMajor() == 5
-                    && getMinor() == 0)
-            {
-                version = "2000";
-            }
-            // Windows NT
-            else if (getMajor() == 4)
-            {
-                version = "NT 4";
+		// see
+		// http://msdn.microsoft.com/en-us/library/windows/desktop/ms724833%28v=vs.85%29.aspx
+		if (getPlatformId() == WinNT.VER_PLATFORM_WIN32_NT) {
+			// 8.1
+			if (getMajor() == 6 && getMinor() == 3
+					&& getProductType() == WinNT.VER_NT_WORKSTATION) {
+				version = "8.1";
+			}
+			// Server 2008 R2
+			else if (getMajor() == 6 && getMinor() == 3
+					&& getProductType() != WinNT.VER_NT_WORKSTATION) {
+				version = "Server 2012 R2";
+			}
+			// 8
+			else if (getMajor() == 6 && getMinor() == 2
+					&& getProductType() == WinNT.VER_NT_WORKSTATION) {
+				version = "8";
+			}
+			// Server 2008
+			else if (getMajor() == 6 && getMinor() == 2
+					&& getProductType() != WinNT.VER_NT_WORKSTATION) {
+				version = "Server 2012";
+			}
+			// 7
+			else if (getMajor() == 6 && getMinor() == 1
+					&& getProductType() == WinNT.VER_NT_WORKSTATION) {
+				version = "7";
+			}
+			// Server 2008 R2
+			else if (getMajor() == 6 && getMinor() == 1
+					&& getProductType() != WinNT.VER_NT_WORKSTATION) {
+				version = "Server 2008 R2";
+			}
+			// Server 2008
+			else if (getMajor() == 6 && getMinor() == 0
+					&& getProductType() != WinNT.VER_NT_WORKSTATION) {
+				version = "Server 2008";
+			}
+			// Vista
+			else if (getMajor() == 6 && getMinor() == 0
+					&& getProductType() == WinNT.VER_NT_WORKSTATION) {
+				version = "Vista";
+			}
+			// Server 2003
+			else if (getMajor() == 5
+					&& getMinor() == 2
+					&& getProductType() != WinNT.VER_NT_WORKSTATION
+					&& User32.INSTANCE.GetSystemMetrics(WinUser.SM_SERVERR2) != 0) {
+				version = "Server 2003";
+			}
+			// Server 2003 R2
+			else if (getMajor() == 5
+					&& getMinor() == 2
+					&& getProductType() != WinNT.VER_NT_WORKSTATION
+					&& User32.INSTANCE.GetSystemMetrics(WinUser.SM_SERVERR2) == 0) {
+				version = "Server 2003 R2";
+			}
+			// XP 64 bit
+			else if (getMajor() == 5 && getMinor() == 2
+					&& getProductType() == WinNT.VER_NT_WORKSTATION) {
+				version = "XP";
+			}
+			// XP 32 bit
+			else if (getMajor() == 5 && getMinor() == 1) {
+				version = "XP";
+			}
+			// 2000
+			else if (getMajor() == 5 && getMinor() == 0) {
+				version = "2000";
+			}
+			// Windows NT
+			else if (getMajor() == 4) {
+				version = "NT 4";
 
-                if ("Service Pack 6".equals(getServicePack())) {
-                    if (Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE,
-                            "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix\\Q246009")) {
-                        return "NT4 SP6a";
-                    }
-                }
+				if ("Service Pack 6".equals(getServicePack())) {
+					if (Advapi32Util
+							.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE,
+									"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix\\Q246009")) {
+						return "NT4 SP6a";
+					}
+				}
 
-            } else {
-                throw new RuntimeException("Unsupported Windows NT version: "
-                        + _versionInfo.toString());
-            }
+			} else {
+				throw new RuntimeException("Unsupported Windows NT version: "
+						+ _versionInfo.toString());
+			}
 
-            if (_versionInfo.wServicePackMajor.intValue() > 0) {
-                version = version + " SP" + _versionInfo.wServicePackMajor.intValue();
-            }
+			if (_versionInfo.wServicePackMajor.intValue() > 0) {
+				version = version + " SP"
+						+ _versionInfo.wServicePackMajor.intValue();
+			}
 
-        } else if (getPlatformId() == WinNT.VER_PLATFORM_WIN32_WINDOWS) {
-            if (getMajor() == 4
-                    && getMinor() == 90)
-            {
-                version = "ME";
-            }
-            else if (getMajor() == 4 &&
-                    getMinor() == 10)
-            {
-                if (_versionInfo.szCSDVersion[1] == 'A') {
-                    version = "98 SE";
-                } else {
-                    version = "98";
-                }
-            }
-            else if (getMajor() == 4
-                    && getMinor() == 0)
-            {
-                if (_versionInfo.szCSDVersion[1] == 'C' || _versionInfo.szCSDVersion[1] == 'B') {
-                    version = "95 OSR2";
-                } else {
-                    version = "95";
-                }
-            } else {
-                throw new RuntimeException("Unsupported Windows 9x version: "
-                        + _versionInfo.toString());
-            }
-        } else {
-            throw new RuntimeException("Unsupported Windows platform: "
-                    + _versionInfo.toString());
-        }
+		} else if (getPlatformId() == WinNT.VER_PLATFORM_WIN32_WINDOWS) {
+			if (getMajor() == 4 && getMinor() == 90) {
+				version = "ME";
+			} else if (getMajor() == 4 && getMinor() == 10) {
+				if (_versionInfo.szCSDVersion[1] == 'A') {
+					version = "98 SE";
+				} else {
+					version = "98";
+				}
+			} else if (getMajor() == 4 && getMinor() == 0) {
+				if (_versionInfo.szCSDVersion[1] == 'C'
+						|| _versionInfo.szCSDVersion[1] == 'B') {
+					version = "95 OSR2";
+				} else {
+					version = "95";
+				}
+			} else {
+				throw new RuntimeException("Unsupported Windows 9x version: "
+						+ _versionInfo.toString());
+			}
+		} else {
+			throw new RuntimeException("Unsupported Windows platform: "
+					+ _versionInfo.toString());
+		}
 
-        return version;
-    }
+		return version;
+	}
 
-    public OSVersionInfoEx(OSVERSIONINFOEX versionInfo) {
-        _versionInfo = versionInfo;
-    }
+	public OSVersionInfoEx(OSVERSIONINFOEX versionInfo) {
+		_versionInfo = versionInfo;
+	}
 }

--- a/src/main/java/oshi/util/ExecutingCommand.java
+++ b/src/main/java/oshi/util/ExecutingCommand.java
@@ -40,7 +40,9 @@ public class ExecutingCommand {
 
 	/**
 	 * Return first line of response for selected command
-	 * @param cmd2launch String command to be launched
+	 * 
+	 * @param cmd2launch
+	 *            String command to be launched
 	 * @return String or null
 	 */
 	public static String getFirstAnswer(String cmd2launch) {
@@ -48,10 +50,15 @@ public class ExecutingCommand {
 	}
 
 	/**
-	 * Return response on selected line index (0-based) after running selected command
-	 * @param cmd2launch String command to be launched
-	 * @param answerIdx int index of line in response of the command
-	 * @return String whole line in response or null if invalid index or running of command fails
+	 * Return response on selected line index (0-based) after running selected
+	 * command
+	 * 
+	 * @param cmd2launch
+	 *            String command to be launched
+	 * @param answerIdx
+	 *            int index of line in response of the command
+	 * @return String whole line in response or null if invalid index or running
+	 *         of command fails
 	 */
 	public static String getAnswerAt(String cmd2launch, int answerIdx) {
 		ArrayList<String> sa = ExecutingCommand.runNative(cmd2launch);
@@ -61,5 +68,5 @@ public class ExecutingCommand {
 		else
 			return null;
 	}
-	
+
 }

--- a/src/main/java/oshi/util/FileUtil.java
+++ b/src/main/java/oshi/util/FileUtil.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Daniel Widdis, 2015
+ * widdis[at]gmail[dot]com
+ * All Rights Reserved
+ * Eclipse Public License (EPLv1)
+ * http://oshi.codeplex.com/license
+ */
+package oshi.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Read an entire file at one time and return a list of Strings for each line.
+ * Intended primarily for Linux /proc filesystem to avoid recalculating file
+ * contents on iterative reads
+ * 
+ * @author widdis[at]gmail[dot]com
+ */
+public class FileUtil {
+	public static List<String> readFile(String filename) throws IOException {
+		File f = new File(filename);
+		byte[] bytes = Files.readAllBytes(f.toPath());
+		String s = new String(bytes, "UTF-8");
+		return Arrays.asList(s.split(System.getProperty("line.separator")));
+	}
+}

--- a/src/main/java/oshi/util/FormatUtil.java
+++ b/src/main/java/oshi/util/FormatUtil.java
@@ -11,31 +11,32 @@ import java.math.BigDecimal;
 
 /**
  * String formatting utility.
+ * 
  * @author dblock[at]dblock[dot]org
  */
 public abstract class FormatUtil {
 
 	/**
-	 * Added these variable for easier reading
-	 * Using the IEC Standard for naming the units
+	 * Added these variable for easier reading Using the IEC Standard for naming
+	 * the units
 	 * (http://en.wikipedia.org/wiki/International_Electrotechnical_Commission)
 	 */
-    final private static long kibiByte = 1024L;
-    final private static long mebiByte = kibiByte * kibiByte;
-    final private static long gibiByte = mebiByte * kibiByte;
-    final private static long tebiByte = gibiByte * kibiByte;
-    final private static long pebiByte = tebiByte * kibiByte;
+	final private static long kibiByte = 1024L;
+	final private static long mebiByte = kibiByte * kibiByte;
+	final private static long gibiByte = mebiByte * kibiByte;
+	final private static long tebiByte = gibiByte * kibiByte;
+	final private static long pebiByte = tebiByte * kibiByte;
 
 	/**
-	 * Format bytes into a string to a rounded string representation.
-	 * Using the JEDEC representation for KB, MB and GB
-	 * Using the IEC representation for TiB
+	 * Format bytes into a string to a rounded string representation. Using the
+	 * JEDEC representation for KB, MB and GB Using the IEC representation for
+	 * TiB
+	 * 
 	 * @param bytes
-	 *  Bytes.
-	 * @return
-	 *  Rounded string representation of the byte size.
+	 *            Bytes.
+	 * @return Rounded string representation of the byte size.
 	 */
-    public static String formatBytes(long bytes) {
+	public static String formatBytes(long bytes) {
 		if (bytes == 1) { // bytes
 			return String.format("%d byte", bytes);
 		} else if (bytes < kibiByte) { // bytes
@@ -50,16 +51,16 @@ public abstract class FormatUtil {
 			return String.format("%.1f MB", (double) bytes / mebiByte);
 		} else if (bytes % gibiByte == 0 && bytes < tebiByte) { // GB
 			return String.format("%.0f GB", (double) bytes / gibiByte);
-		} else if (bytes < tebiByte ) {
+		} else if (bytes < tebiByte) {
 			return String.format("%.1f GB", (double) bytes / gibiByte);
 		} else if (bytes % tebiByte == 0 && bytes < pebiByte) { // TiB
 			return String.format("%.0f TiB", (double) bytes / tebiByte);
-		} else if (bytes < pebiByte ) {
+		} else if (bytes < pebiByte) {
 			return String.format("%.1f TiB", (double) bytes / tebiByte);
 		} else {
 			return String.format("%d bytes", bytes);
 		}
-    }
+	}
 
 	/**
 	 * Round to certain number of decimals

--- a/src/test/java/oshi/util/FileUtilTest.java
+++ b/src/test/java/oshi/util/FileUtilTest.java
@@ -1,0 +1,35 @@
+package oshi.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+public class FileUtilTest {
+
+	private static String THISCLASS = "src/test/java/oshi/util/FileUtilTest.java";
+
+	@Test
+	public void testReadFile() {
+		List<String> thisFile = null;
+		try {
+			thisFile = FileUtil.readFile(THISCLASS);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		// Comment ONE line
+		int lineOne = 0;
+		// Comment TWO line
+		int lineTwo = 0;
+		for (int i = 0; i < thisFile.size(); i++) {
+			String line = thisFile.get(i);
+			if (line.contains("Comment ONE line"))
+				lineOne = i;
+			if (line.contains("Comment TWO line"))
+				lineTwo = i;
+		}
+		assertEquals(2, lineTwo - lineOne);
+	}
+}

--- a/src/test/java/oshi/util/FormatUtilTest.java
+++ b/src/test/java/oshi/util/FormatUtilTest.java
@@ -7,41 +7,43 @@ import static org.junit.Assert.*;
 
 public class FormatUtilTest {
 
-    private static char DECIMAL_SEPARATOR;
+	private static char DECIMAL_SEPARATOR;
 
-    @BeforeClass
-    public static void setUpClass() {
-        // use decimal separator according to current locale
-        DECIMAL_SEPARATOR = DecimalFormatSymbols.getInstance().getDecimalSeparator();
-    }
+	@BeforeClass
+	public static void setUpClass() {
+		// use decimal separator according to current locale
+		DECIMAL_SEPARATOR = DecimalFormatSymbols.getInstance()
+				.getDecimalSeparator();
+	}
 
-    @Test
-    public void testFormatBytes() {
-        assertEquals("0 bytes", FormatUtil.formatBytes(0));
-        assertEquals("1 byte", FormatUtil.formatBytes(1));
-        assertEquals("532 bytes", FormatUtil.formatBytes(532));
-        assertEquals("1 KB", FormatUtil.formatBytes(1024));
-        assertEquals("1 GB", FormatUtil.formatBytes(1024 * 1024 * 1024));
-        assertEquals("1 TiB", FormatUtil.formatBytes(1099511627776L));
-    }
+	@Test
+	public void testFormatBytes() {
+		assertEquals("0 bytes", FormatUtil.formatBytes(0));
+		assertEquals("1 byte", FormatUtil.formatBytes(1));
+		assertEquals("532 bytes", FormatUtil.formatBytes(532));
+		assertEquals("1 KB", FormatUtil.formatBytes(1024));
+		assertEquals("1 GB", FormatUtil.formatBytes(1024 * 1024 * 1024));
+		assertEquals("1 TiB", FormatUtil.formatBytes(1099511627776L));
+	}
 
-    @Test
-    public void testFormatBytesWithDecimalSeparator() {
-        String expected1 = "1" + DECIMAL_SEPARATOR + "3 KB";
-        String expected2 = "2" + DECIMAL_SEPARATOR + "3 MB";
-        String expected3 = "2" + DECIMAL_SEPARATOR + "2 GB";
-        String expected4 = "1" + DECIMAL_SEPARATOR + "1 TiB";
-        assertEquals(expected1, FormatUtil.formatBytes(1340));
-        assertEquals(expected2, FormatUtil.formatBytes(2400016));
-        assertEquals(expected3, FormatUtil.formatBytes(2400000000L));
-        assertEquals(expected4, FormatUtil.formatBytes(1099511627776L + 109951162777L));
-    }
+	@Test
+	public void testFormatBytesWithDecimalSeparator() {
+		String expected1 = "1" + DECIMAL_SEPARATOR + "3 KB";
+		String expected2 = "2" + DECIMAL_SEPARATOR + "3 MB";
+		String expected3 = "2" + DECIMAL_SEPARATOR + "2 GB";
+		String expected4 = "1" + DECIMAL_SEPARATOR + "1 TiB";
+		assertEquals(expected1, FormatUtil.formatBytes(1340));
+		assertEquals(expected2, FormatUtil.formatBytes(2400016));
+		assertEquals(expected3, FormatUtil.formatBytes(2400000000L));
+		assertEquals(expected4,
+				FormatUtil.formatBytes(1099511627776L + 109951162777L));
+	}
 
-    @Test
-    public void testRound() {
-        assertEquals(42.42, FormatUtil.round(42.423f, 2), 0.00001f);
-        assertEquals(42.43, FormatUtil.round(42.425f, 2), 0.00001f);
-        assertEquals(42.5, FormatUtil.round(42.499f, 2), 0.00001f);
-        assertEquals(42, FormatUtil.round(42, 2), 0.00001f);
-    }
+	@Test
+	public void testRound() {
+		assertEquals(42.42, FormatUtil.round(42.423f, 2), 0.00001f);
+		assertEquals(42.43, FormatUtil.round(42.425f, 2), 0.00001f);
+		assertEquals(42.5, FormatUtil.round(42.499f, 2), 0.00001f);
+		assertEquals(42, FormatUtil.round(42, 2), 0.00001f);
+	}
 }


### PR DESCRIPTION
Submitted for comment/discussion.  No feelings will be hurt if it's rejected. :)   Some comments:
- Only Linux function which is easily exposed to JNA is sysinfo, and that's really only good for Total ram.  You can also get Free ram from it, but as previously noted, that doesn't account for the true amount available.
- I tried various methods to get the other components of available.  I managed inactive using the meminfo() function (updates global variables) and then reading the kb_inactive global variable.  Unfortunately the necessary library for these was "libprocps.so.3".  I am not sure we should specify the version (version 4 may be out soon) and my system I set up as a testbed (Ubuntu 14.04 LTS) did not have a link from the non-versioned extension (so just plain "procps" didn't work to locate the library), so I'm not sure how portable this would be.
- Even when I got the inactive, the sum of free+inactive didn't equal available on my system. I also had "reclaimable".  Digging into the source code, I also found various minimum thresholds before swap space was used.   
The bottom line, parsing /proc/meminfo is fast, and it's really a virtual filesystem intended to provide access to all the kernel info we're trying to get, so it (and the other /proc file reading elsewhere in the linux patch) is really probably the way to go.  And it's reasonable to just go back to that for total as well.

The only method that might benefit from changing is the total ram call, which is shown in this pull request.  You'll notice a few things:
- I had to write two versions of the structure, because on a 64-bit system, the structure copied from the linux source includes a zero-length array that JNA chokes on.  (And I can't even extend one to get the other because the fields are loaded from children first and then parent, so the mapping to the C structure would be wrong.)
- I finally realized the reason for the class variable totalmemory, and the if (totalmemory==0) check.  It, like all the fields in the CentralProcessor class, keeps the old value rather than always fetching the new value.   So I should, perhaps, put that conditional back in the Mac OS version of things.  

I did find a file not closed (CentralProcessor line 181) so there may be at least one line that needs to be kept from this PR even if I roll back everything else.

Finally, lots of format changes creating diffs.  Do you have a coding conventions/formatting conventions page to prevent this from making diffs unreadble?