### PR TITLE
Support for processor frequency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Output
 /target/
+/bin/
+/.project
+/.settings/
+/.classpath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Next
 * [#15](https://github.com/dblock/oshi/pull/15), [#18](https://github.com/dblock/oshi/pull/18): Added support for CPU load - [@kamenitxan](https://github.com/kamenitxan), [@Sorceror](https://github.com/Sorceror).
 * [#25](https://github.com/dblock/oshi/pull/25), [#29](https://github.com/dblock/oshi/pull/29): Included inactive/reclaimable memory amount in GlobalMemory#getAvailable on Mac/Linux - [@dbwiddis](https://github.com/dbwiddis).
 * [#27](https://github.com/dblock/oshi/pull/27): Replaced all Mac OS X command line parsing with JNA or System properties - [@dbwiddis](https://github.com/dbwiddis).
+* [#30](https://github.com/dblock/oshi/pull/30): Added processor vendor frequency information - [@alessiofachechi](https://github.com/alessiofachechi).
 * [#32](https://github.com/dblock/oshi/pull/32): Added battery state information - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here.
 

--- a/src/main/java/oshi/hardware/Processor.java
+++ b/src/main/java/oshi/hardware/Processor.java
@@ -44,6 +44,18 @@ public interface Processor {
 	 *            Name.
 	 */
 	void setName(String name);
+	
+	/**
+	 * Vendor frequency (in Hz).
+	 * @return Processor frequency.
+	 */
+	long getVendorFreq();
+	
+	/**
+	 * Set processor vendor frequency (in Hz).
+	 * @param freq Frequency.
+	 */
+	void setVendorFreq(long freq);
 
 	/**
 	 * Identifier, eg. x86 Family 6 Model 15 Stepping 10.

--- a/src/main/java/oshi/software/os/linux/proc/CentralProcessor.java
+++ b/src/main/java/oshi/software/os/linux/proc/CentralProcessor.java
@@ -11,9 +11,12 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import oshi.hardware.Processor;
 import oshi.util.FormatUtil;
+import oshi.util.ParseUtil;
 
 /**
  * A CPU as defined in Linux /proc.
@@ -27,7 +30,8 @@ public class CentralProcessor implements Processor {
 	private String _stepping;
 	private String _model;
 	private String _family;
-	private boolean _cpu64;
+	private Long _freq = null;
+	private Boolean _cpu64;
 
 	/**
 	 * Vendor identifier, eg. GenuineIntel.
@@ -65,6 +69,40 @@ public class CentralProcessor implements Processor {
 	 */
 	public void setName(String name) {
 		_name = name;
+	}
+
+	/**
+	 * Vendor frequency (in Hz), eg. for processor named Intel(R) Core(TM)2 Duo
+	 * CPU T7300 @ 2.00GHz the vendor frequency is 2000000000.
+	 * 
+	 * @return Processor frequency or -1 if unknown.
+	 * 
+	 * @author alessio.fachechi[at]gmail[dot]com
+	 */
+	public long getVendorFreq() {
+		if (_freq == null) {
+			Pattern pattern = Pattern.compile("@ (.*)$");
+			Matcher matcher = pattern.matcher(getName());
+
+			if (matcher.find()) {
+				String unit = matcher.group(1);
+				_freq = ParseUtil.parseHertz(unit);
+			} else {
+				_freq = -1L;
+			}
+		}
+
+		return _freq.longValue();
+	}
+
+	/**
+	 * Set vendor frequency.
+	 * 
+	 * @param frequency
+	 *            Frequency.
+	 */
+	public void setVendorFreq(long freq) {
+		_freq = Long.valueOf(freq);
 	}
 
 	/**
@@ -106,7 +144,7 @@ public class CentralProcessor implements Processor {
 	 * @return True if cpu is 64bit.
 	 */
 	public boolean isCpu64bit() {
-		return _cpu64;
+		return _cpu64.booleanValue();
 	}
 
 	/**
@@ -116,7 +154,7 @@ public class CentralProcessor implements Processor {
 	 *            True if cpu is 64.
 	 */
 	public void setCpu64(boolean cpu64) {
-		_cpu64 = cpu64;
+		_cpu64 = Boolean.valueOf(cpu64);
 	}
 
 	/**

--- a/src/main/java/oshi/util/FormatUtil.java
+++ b/src/main/java/oshi/util/FormatUtil.java
@@ -28,6 +28,15 @@ public abstract class FormatUtil {
 	final private static long pebiByte = tebiByte * kibiByte;
 
 	/**
+	 * Hertz related variables
+	 */
+	final private static long kiloHertz = 1000L;
+	final private static long megaHertz = kiloHertz * kiloHertz;
+	final private static long gigaHertz = megaHertz * kiloHertz;
+	final private static long teraHertz = gigaHertz * kiloHertz;
+	final private static long petaHertz = teraHertz * kiloHertz;
+
+	/**
 	 * Format bytes into a string to a rounded string representation. Using the
 	 * JEDEC representation for KB, MB and GB Using the IEC representation for
 	 * TiB
@@ -59,6 +68,37 @@ public abstract class FormatUtil {
 			return String.format("%.1f TiB", (double) bytes / tebiByte);
 		} else {
 			return String.format("%d bytes", bytes);
+		}
+	}
+
+	/**
+	 * Format hertz into a string to a rounded string representation.
+	 * 
+	 * @param hertz
+	 *            Hertz.
+	 * @return Rounded string representation of the hertz size.
+	 */
+	public static String formatHertz(long hertz) {
+		if (hertz < kiloHertz ) { // Hz
+			return String.format("%d Hz", hertz);
+		} else if (hertz < megaHertz && hertz % kiloHertz == 0) { // KHz
+			return String.format("%.0f kHz", (double) hertz / kiloHertz);
+		} else if (hertz < megaHertz) {
+			return String.format("%.1f kHz", (double) hertz / kiloHertz);
+		} else if (hertz < gigaHertz && hertz % megaHertz == 0) { // MHz
+			return String.format("%.0f MHz", (double) hertz / megaHertz);
+		} else if (hertz < gigaHertz) {
+			return String.format("%.1f MHz", (double) hertz / megaHertz);
+		} else if (hertz < teraHertz && hertz % gigaHertz == 0) { // GHz
+			return String.format("%.0f GHz", (double) hertz / gigaHertz);
+		} else if (hertz < teraHertz) {
+			return String.format("%.1f GHz", (double) hertz / gigaHertz);
+		} else if (hertz < petaHertz && hertz % teraHertz == 0) { // THz
+			return String.format("%.0f THz", (double) hertz / teraHertz);
+		} else if (hertz < petaHertz) {
+			return String.format("%.1f THz", (double) hertz / teraHertz);
+		} else {
+			return String.format("%d Hz", hertz);
 		}
 	}
 

--- a/src/main/java/oshi/util/ParseUtil.java
+++ b/src/main/java/oshi/util/ParseUtil.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Daniel Doubrovkine, 2010
+ * dblock[at]dblock[dot]org
+ * All Rights Reserved
+ * Eclipse Public License (EPLv1)
+ * http://oshi.codeplex.com/license
+ */
+package oshi.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * String parsing utility.
+ * 
+ * @author alessio.fachechi[at]gmail[dot]com
+ */
+public abstract class ParseUtil {
+
+	/**
+	 * Hertz related variables
+	 */
+	final private static String Hertz = "Hz";
+	final private static String kiloHertz = "k" + Hertz;
+	final private static String megaHertz = "M" + Hertz;
+	final private static String gigaHertz = "G" + Hertz;
+	final private static String teraHertz = "T" + Hertz;
+	final private static String petaHertz = "P" + Hertz;
+	final private static Map<String, Long> multipliers;
+
+	static {
+		multipliers = new HashMap<String, Long>();
+		multipliers.put(Hertz, 1L);
+		multipliers.put(kiloHertz, 1000L);
+		multipliers.put(megaHertz, 1000000L);
+		multipliers.put(gigaHertz, 1000000000L);
+		multipliers.put(teraHertz, 1000000000000L);
+		multipliers.put(petaHertz, 1000000000000000L);
+	}
+
+	/**
+	 * Parse hertz from a string, eg. "2.00MHz" in 2000000L.
+	 * 
+	 * @param hertz
+	 *            Hertz size.
+	 * @return {@link Long} Hertz value or -1 if not parsable.
+	 * 
+	 * @author alessio.fachechi[at]gmail[dot]com
+	 */
+	public static long parseHertz(String hertz) {
+		Pattern pattern = Pattern.compile("(\\d+(.\\d+)?) ?([kMGT]?Hz)");
+		Matcher matcher = pattern.matcher(hertz.trim());
+
+		if (matcher.find() && (matcher.groupCount() == 3)) {
+			try {
+				Double value = Double.valueOf(matcher.group(1));
+				String unit = matcher.group(3);
+
+				if (multipliers.containsKey(unit)) {
+					value = value * multipliers.get(unit);
+					return value.longValue();
+				}
+			} catch (NumberFormatException e) {
+			}
+		}
+
+		return -1L;
+	}
+
+}

--- a/src/test/java/oshi/SystemInfoTest.java
+++ b/src/test/java/oshi/SystemInfoTest.java
@@ -57,6 +57,14 @@ public class SystemInfoTest {
 		assertTrue(hal.getProcessors()[0].getLoad() >= 0
 				&& hal.getProcessors()[0].getLoad() <= 100);
 	}
+    
+    @Test
+    public void testCpuVendorFreq() {
+        SystemInfo si = new SystemInfo();
+        HardwareAbstractionLayer hal = si.getHardware();
+		assertTrue(hal.getProcessors()[0].getVendorFreq() == -1
+				|| hal.getProcessors()[0].getVendorFreq() > 0);
+    }
 
 	@Test
 	public void testPowerSource() {

--- a/src/test/java/oshi/util/FormatUtilTest.java
+++ b/src/test/java/oshi/util/FormatUtilTest.java
@@ -9,49 +9,53 @@ import org.junit.Test;
 
 public class FormatUtilTest {
 
-	private static char DECIMAL_SEPARATOR;
+    private static char DECIMAL_SEPARATOR;
 
-	@BeforeClass
-	public static void setUpClass() {
-		// use decimal separator according to current locale
-		DecimalFormatSymbols syms = new DecimalFormatSymbols();
-		DECIMAL_SEPARATOR = syms.getDecimalSeparator();
-	}
+    @BeforeClass
+    public static void setUpClass() {
+        // use decimal separator according to current locale
+    	DecimalFormatSymbols syms = new DecimalFormatSymbols();
+        DECIMAL_SEPARATOR = syms.getDecimalSeparator();
+    }
 
-	@Test
-	public void testFormatBytes() {
-		assertEquals("0 bytes", FormatUtil.formatBytes(0));
-		assertEquals("1 byte", FormatUtil.formatBytes(1));
-		assertEquals("532 bytes", FormatUtil.formatBytes(532));
-		assertEquals("1 KB", FormatUtil.formatBytes(1024));
-		assertEquals("1 GB", FormatUtil.formatBytes(1024 * 1024 * 1024));
-		assertEquals("1 TiB", FormatUtil.formatBytes(1099511627776L));
-	}
+    @Test
+    public void testFormatBytes() {
+        assertEquals("0 bytes", FormatUtil.formatBytes(0));
+        assertEquals("1 byte", FormatUtil.formatBytes(1));
+        assertEquals("532 bytes", FormatUtil.formatBytes(532));
+        assertEquals("1 KB", FormatUtil.formatBytes(1024));
+        assertEquals("1 GB", FormatUtil.formatBytes(1024 * 1024 * 1024));
+        assertEquals("1 TiB", FormatUtil.formatBytes(1099511627776L));
+    }
 
-	@Test
-	public void testFormatBytesWithDecimalSeparator() {
-		String expected1 = "1" + DECIMAL_SEPARATOR + "3 KB";
-		String expected2 = "2" + DECIMAL_SEPARATOR + "3 MB";
-		String expected3 = "2" + DECIMAL_SEPARATOR + "2 GB";
-		String expected4 = "1" + DECIMAL_SEPARATOR + "1 TiB";
-		assertEquals(expected1, FormatUtil.formatBytes(1340));
-		assertEquals(expected2, FormatUtil.formatBytes(2400016));
-		assertEquals(expected3, FormatUtil.formatBytes(2400000000L));
-		assertEquals(expected4,
-				FormatUtil.formatBytes(1099511627776L + 109951162777L));
-	}
+    @Test
+    public void testFormatBytesWithDecimalSeparator() {
+        String expected1 = "1" + DECIMAL_SEPARATOR + "3 KB";
+        String expected2 = "2" + DECIMAL_SEPARATOR + "3 MB";
+        String expected3 = "2" + DECIMAL_SEPARATOR + "2 GB";
+        String expected4 = "1" + DECIMAL_SEPARATOR + "1 TiB";
+        assertEquals(expected1, FormatUtil.formatBytes(1340));
+        assertEquals(expected2, FormatUtil.formatBytes(2400016));
+        assertEquals(expected3, FormatUtil.formatBytes(2400000000L));
+        assertEquals(expected4, FormatUtil.formatBytes(1099511627776L + 109951162777L));
+    }
 
-	@Test
-	public void testRound() {
-		assertEquals(42.42, FormatUtil.round(42.423f, 2), 0.00001f);
-		assertEquals(42.43, FormatUtil.round(42.425f, 2), 0.00001f);
-		assertEquals(42.5, FormatUtil.round(42.499f, 2), 0.00001f);
-		assertEquals(42, FormatUtil.round(42, 2), 0.00001f);
-	}
+    @Test
+    public void testFormatHertz() {
+        assertEquals("0 Hz", FormatUtil.formatHertz(0));
+        assertEquals("1 Hz", FormatUtil.formatHertz(1));
+        assertEquals("999 Hz", FormatUtil.formatHertz(999));
+        assertEquals("1 kHz", FormatUtil.formatHertz(1000));
+        assertEquals("1 MHz", FormatUtil.formatHertz(1000 * 1000));
+        assertEquals("1 GHz", FormatUtil.formatHertz(1000 * 1000 * 1000));
+        assertEquals("1 THz", FormatUtil.formatHertz(1000L * 1000L * 1000L * 1000L));
+    }
 
-	@Test
-	public void testUnsignedInt() {
-		assertEquals(FormatUtil.getUnsignedInt(Integer.MIN_VALUE),
-				(long) Integer.MAX_VALUE + 1L);
-	}
+    @Test
+    public void testRound() {
+        assertEquals(42.42, FormatUtil.round(42.423f, 2), 0.00001f);
+        assertEquals(42.43, FormatUtil.round(42.425f, 2), 0.00001f);
+        assertEquals(42.5, FormatUtil.round(42.499f, 2), 0.00001f);
+        assertEquals(42, FormatUtil.round(42, 2), 0.00001f);
+    }
 }

--- a/src/test/java/oshi/util/ParseUtilTest.java
+++ b/src/test/java/oshi/util/ParseUtilTest.java
@@ -1,0 +1,20 @@
+package oshi.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ParseUtilTest {
+
+	@Test
+	public void testParseHertz() {
+		assertEquals(1L, ParseUtil.parseHertz("1Hz"));
+		assertEquals(500L, ParseUtil.parseHertz("500 Hz"));
+		assertEquals(1000L, ParseUtil.parseHertz("1kHz"));
+		assertEquals(1000000L, ParseUtil.parseHertz("1MHz"));
+		assertEquals(1000000000L, ParseUtil.parseHertz("1GHz"));
+		assertEquals(1500000000L, ParseUtil.parseHertz("1.5GHz"));
+		assertEquals(1000000000000L, ParseUtil.parseHertz("1THz"));
+	}
+
+}


### PR DESCRIPTION
Added the `getFreq` and `setFreq` methods to the `Processor` interface and for its implementations for Linux, Windows and Mac.