### PR TITLE
jautodoc remainder of non javadoc'd items.

### DIFF
--- a/src/main/java/oshi/hardware/package-info.java
+++ b/src/main/java/oshi/hardware/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.hardware;

--- a/src/main/java/oshi/package-info.java
+++ b/src/main/java/oshi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi;

--- a/src/main/java/oshi/software/os/linux/package-info.java
+++ b/src/main/java/oshi/software/os/linux/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os.linux;

--- a/src/main/java/oshi/software/os/linux/proc/package-info.java
+++ b/src/main/java/oshi/software/os/linux/proc/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os.linux.proc;

--- a/src/main/java/oshi/software/os/mac/local/package-info.java
+++ b/src/main/java/oshi/software/os/mac/local/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os.mac.local;

--- a/src/main/java/oshi/software/os/mac/package-info.java
+++ b/src/main/java/oshi/software/os/mac/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os.mac;

--- a/src/main/java/oshi/software/os/package-info.java
+++ b/src/main/java/oshi/software/os/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os;

--- a/src/main/java/oshi/software/os/windows/nt/package-info.java
+++ b/src/main/java/oshi/software/os/windows/nt/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os.windows.nt;

--- a/src/main/java/oshi/software/os/windows/package-info.java
+++ b/src/main/java/oshi/software/os/windows/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.software.os.windows;

--- a/src/main/java/oshi/util/package-info.java
+++ b/src/main/java/oshi/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides...
+ */
+package oshi.util;

--- a/src/test/java/oshi/SystemInfoTest.java
+++ b/src/test/java/oshi/SystemInfoTest.java
@@ -40,10 +40,15 @@ import oshi.util.FormatUtil;
 import com.sun.jna.Platform;
 
 /**
+ * The Class SystemInfoTest.
+ *
  * @author dblock[at]dblock[dot]org
  */
 public class SystemInfoTest {
 
+	/**
+     * Test get version.
+     */
 	@Test
 	public void testGetVersion() {
 		SystemInfo si = new SystemInfo();
@@ -54,6 +59,9 @@ public class SystemInfoTest {
 		assertTrue(os.toString().length() > 0);
 	}
 
+	/**
+     * Test get processors.
+     */
 	@Test
 	public void testGetProcessors() {
 		SystemInfo si = new SystemInfo();
@@ -61,6 +69,9 @@ public class SystemInfoTest {
 		assertTrue(hal.getProcessors().length > 0);
 	}
 
+	/**
+     * Test get memory.
+     */
 	@Test
 	public void testGetMemory() {
 		SystemInfo si = new SystemInfo();
@@ -72,6 +83,9 @@ public class SystemInfoTest {
 		assertTrue(memory.getAvailable() <= memory.getTotal());
 	}
 
+	/**
+     * Test cpu load.
+     */
 	@SuppressWarnings("deprecation")
 	@Test
 	public void testCpuLoad() {
@@ -81,6 +95,9 @@ public class SystemInfoTest {
 				&& hal.getProcessors()[0].getLoad() <= 100);
 	}
 
+	/**
+     * Test cpu load ticks.
+     */
 	@Test
 	public void testCpuLoadTicks() {
 		SystemInfo si = new SystemInfo();
@@ -88,6 +105,9 @@ public class SystemInfoTest {
 		assertEquals(4, hal.getProcessors()[0].getCpuLoadTicks().length);
 	}
 
+	/**
+     * Test system cpu load.
+     */
 	@Test
 	public void testSystemCpuLoad() {
 		SystemInfo si = new SystemInfo();
@@ -96,6 +116,9 @@ public class SystemInfoTest {
 		assertTrue(cpuLoad >= 0.0 && cpuLoad <= 1.0);
 	}
 
+	/**
+     * Test system load average.
+     */
 	@Test
 	public void testSystemLoadAverage() {
 		if (Platform.isMac() || Platform.isLinux()) {
@@ -105,6 +128,9 @@ public class SystemInfoTest {
 		}
 	}
 
+	/**
+     * Test cpu vendor freq.
+     */
 	@Test
 	public void testCpuVendorFreq() {
 		SystemInfo si = new SystemInfo();
@@ -113,6 +139,9 @@ public class SystemInfoTest {
 				|| hal.getProcessors()[0].getVendorFreq() > 0);
 	}
 
+	/**
+     * Test power source.
+     */
 	@Test
 	public void testPowerSource() {
 		SystemInfo si = new SystemInfo();
@@ -129,6 +158,12 @@ public class SystemInfoTest {
 		}
 	}
 
+	/**
+     * Test file system.
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
 	@Test
 	public void testFileSystem() throws IOException {
 		SystemInfo si = new SystemInfo();
@@ -148,6 +183,12 @@ public class SystemInfoTest {
 		}
 	}
 
+	/**
+     * The main method.
+     *
+     * @param args
+     *            the arguments
+     */
 	@SuppressWarnings("deprecation")
 	public static void main(String[] args) {
 		SystemInfo si = new SystemInfo();

--- a/src/test/java/oshi/util/FileUtilTest.java
+++ b/src/test/java/oshi/util/FileUtilTest.java
@@ -23,10 +23,17 @@ import java.util.List;
 
 import org.junit.Test;
 
+/**
+ * The Class FileUtilTest.
+ */
 public class FileUtilTest {
 
+	/** The thisclass. */
 	private static String THISCLASS = "src/test/java/oshi/util/FileUtilTest.java";
 
+	/**
+     * Test read file.
+     */
 	@Test
 	public void testReadFile() {
 		List<String> thisFile = null;

--- a/src/test/java/oshi/util/FormatUtilTest.java
+++ b/src/test/java/oshi/util/FormatUtilTest.java
@@ -23,10 +23,17 @@ import java.text.DecimalFormatSymbols;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * The Class FormatUtilTest.
+ */
 public class FormatUtilTest {
 
+	/** The decimal separator. */
 	private static char DECIMAL_SEPARATOR;
 
+	/**
+     * Sets the up class.
+     */
 	@BeforeClass
 	public static void setUpClass() {
 		// use decimal separator according to current locale
@@ -34,6 +41,9 @@ public class FormatUtilTest {
 		DECIMAL_SEPARATOR = syms.getDecimalSeparator();
 	}
 
+	/**
+     * Test format bytes.
+     */
 	@Test
 	public void testFormatBytes() {
 		assertEquals("0 bytes", FormatUtil.formatBytes(0));
@@ -44,6 +54,9 @@ public class FormatUtilTest {
 		assertEquals("1 TiB", FormatUtil.formatBytes(1099511627776L));
 	}
 
+	/**
+     * Test format bytes with decimal separator.
+     */
 	@Test
 	public void testFormatBytesWithDecimalSeparator() {
 		String expected1 = "1" + DECIMAL_SEPARATOR + "3 KB";
@@ -57,6 +70,9 @@ public class FormatUtilTest {
 				FormatUtil.formatBytes(1099511627776L + 109951162777L));
 	}
 
+	/**
+     * Test format hertz.
+     */
 	@Test
 	public void testFormatHertz() {
 		assertEquals("0 Hz", FormatUtil.formatHertz(0));
@@ -69,6 +85,9 @@ public class FormatUtilTest {
 				FormatUtil.formatHertz(1000L * 1000L * 1000L * 1000L));
 	}
 
+	/**
+     * Test round.
+     */
 	@Test
 	public void testRound() {
 		assertEquals(42.42, FormatUtil.round(42.423f, 2), 0.00001f);

--- a/src/test/java/oshi/util/ParseUtilTest.java
+++ b/src/test/java/oshi/util/ParseUtilTest.java
@@ -20,8 +20,14 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+/**
+ * The Class ParseUtilTest.
+ */
 public class ParseUtilTest {
 
+	/**
+     * Test parse hertz.
+     */
 	@Test
 	public void testParseHertz() {
 		assertEquals(1L, ParseUtil.parseHertz("1Hz"));


### PR DESCRIPTION
Formatting is off a bit in a couple of places.  I missed setting spaces back to tabs.  However, I plan to do another pull sometime soon enforcing formatting which is space based and generally the accepted cross platform usage.  For now this is ok as these are at least aligned together in the right spaces.  Now everything have javadocs.