### PR TITLE
immediate return for "NT4 SP6a" to prevent additional SP to be appended

### DIFF
--- a/src/main/java/oshi/software/os/windows/nt/OSVersionInfoEx.java
+++ b/src/main/java/oshi/software/os/windows/nt/OSVersionInfoEx.java
@@ -159,7 +159,7 @@ public class OSVersionInfoEx implements OperatingSystemVersion {
                 version = "NT 4";
                 if ("Service Pack 6".equals(getServicePack())) {
                     if (Advapi32Util.registryKeyExists(WinReg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix\\Q246009")) {
-                        version = "NT4 SP6a";
+                        return "NT4 SP6a";
                     }
                 }
 


### PR DESCRIPTION
I erroneously replaced the return statement in my previous commit.
Thus, additional SP may be appended to NT4 SP6a and it should not.