### PR TITLE
Use /proc/meminfo as fallback to sysinfo to remove glibc dependence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.1 (in-progress)
 ================
 * [#108](https://github.com/dblock/oshi/pull/108): Added Display info from EDID - [@dbwiddis](https://github.com/dbwiddis).
+* [#111](https://github.com/dblock/oshi/pull/111): Catch exceptions when Linux c library missing - [@dbwiddis](https://github.com/dbwiddis).
 * Your contribution here.
 
 2.0 (11/28/2015)

--- a/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -591,13 +591,21 @@ public class LinuxCentralProcessor
     @Override
     public long getSystemUptime()
     {
-        Sysinfo info = new Sysinfo();
-        if ( 0 != Libc.INSTANCE.sysinfo( info ) )
+        try
         {
-            LOG.error( "Failed to get system uptime. Error code: " + Native.getLastError() );
-            return 0L;
+            Sysinfo info = new Sysinfo();
+            if ( 0 != Libc.INSTANCE.sysinfo( info ) )
+            {
+                LOG.error( "Failed to get system uptime. Error code: " + Native.getLastError() );
+                return 0L;
+            }
+            return info.uptime.longValue();
         }
-        return info.uptime.longValue();
+        catch ( UnsatisfiedLinkError | NoClassDefFoundError e )
+        {
+            LOG.error( "Failed to get uptime from sysinfo. {}", e.getMessage() );
+        }
+        return 0L;
     }
 
     /**


### PR DESCRIPTION
Fixes #105 