### PR TITLE
FIX: initialize cpu64 attribute in false by default

### DIFF
--- a/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
+++ b/src/main/java/oshi/hardware/platform/linux/LinuxCentralProcessor.java
@@ -111,7 +111,7 @@ public class LinuxCentralProcessor implements CentralProcessor {
 
     private Long cpuVendorFreq;
 
-    private Boolean cpu64;
+    private Boolean cpu64 = Boolean.FALSE;
 
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 


### PR DESCRIPTION
+ avoid NullPointer exception with default value in false in cpu64 attribute in LinuxCentralProcessor

issue #131 