### PR TITLE
Reviewing getFileStores() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.5 (in-progress)
 ================
+* [#163](https://github.com/dblock/oshi/pull/163): Reviewing getFileStores() method [@henryx](https://github.com/henryx),
 * Your contribution here.
 
 2.4 (5/02/2016)

--- a/src/main/java/oshi/software/os/OSFileStore.java
+++ b/src/main/java/oshi/software/os/OSFileStore.java
@@ -36,6 +36,8 @@ public class OSFileStore implements OshiJsonObject {
     private JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     private String name;
+    
+    private String mount;
 
     private String description;
 
@@ -58,7 +60,7 @@ public class OSFileStore implements OshiJsonObject {
      *            Total bytes
      */
     public OSFileStore(String newName, String newDescription, long newUsableSpace, long newTotalSpace) {
-        this(newName, newDescription, "unknown", newUsableSpace, newTotalSpace);
+        this(newName, "unknown", newDescription, "unknown", newUsableSpace, newTotalSpace);
     }
 
     /**
@@ -66,6 +68,26 @@ public class OSFileStore implements OshiJsonObject {
      * 
      * @param newName
      *            Name of the filestore
+     * @param newMount
+     *             Mountpoint of the filestore
+     * @param newDescription
+     *            Description of the file store
+     * @param newUsableSpace
+     *            Available/usable bytes
+     * @param newTotalSpace
+     *            Total bytes
+     */
+    public OSFileStore(String newName, String newMount, String newDescription, long newUsableSpace, long newTotalSpace) {
+        this(newName, newMount, newDescription, "unknown", newUsableSpace, newTotalSpace);
+    }
+
+    /**
+     * Creates an OSFileStore with the specified parameters.
+     * 
+     * @param newName
+     *            Name of the filestore
+     * @param newMount
+     *             Mountpoint of the filestore
      * @param newDescription
      *            Description of the file store
      * @param newType
@@ -75,8 +97,9 @@ public class OSFileStore implements OshiJsonObject {
      * @param newTotalSpace
      *            Total bytes
      */
-    public OSFileStore(String newName, String newDescription, String newType, long newUsableSpace, long newTotalSpace) {
+    public OSFileStore(String newName, String newMount, String newDescription, String newType, long newUsableSpace, long newTotalSpace) {
         this.setName(newName);
+        this.setMount(newMount);
         this.setDescription(newDescription);
         this.setType(newType);
         this.setUsableSpace(newUsableSpace);
@@ -100,6 +123,25 @@ public class OSFileStore implements OshiJsonObject {
      */
     public void setName(String value) {
         this.name = value;
+    }
+
+    /**
+     * Mountpoint of the File System
+     * 
+     * @return The mountpoint of the file system
+     */
+    public String getMount() {
+        return this.mount;
+    }
+
+    /**
+     * Sets the mountpoint of the File System
+     * 
+     * @param value
+     *            The mountpoint
+     */
+    public void setMount(String value) {
+        this.mount = value;
     }
 
     /**

--- a/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -51,6 +51,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
      *         volumes. May return disconnected volumes with
      *         {@link OSFileStore#getTotalSpace()} = 0.
      */
+    @Override
     public OSFileStore[] getFileStores() {
         // Parse /proc/self/mounts to map filesystem paths to types
         Map<String, String> fstype = new HashMap<>();
@@ -63,8 +64,8 @@ public class LinuxFileSystem extends AbstractFileSystem {
                 if (split.length < 6) {
                     continue;
                 }
-                fstype.put(split[1].replaceAll("\\\\040", " "), split[2]);
-            }
+                    fstype.put(split[1].replaceAll("\\\\040", " "), split[2]);
+                }
         } catch (IOException e) {
             LOG.error("Error reading /proc/self/mounts. Can't detect filetypes.");
         }
@@ -76,8 +77,8 @@ public class LinuxFileSystem extends AbstractFileSystem {
             // parentheses e.g., "/ (/dev/sda1)" and "/proc (proc)"
             String path = store.toString().replace(" (" + store.name() + ")", "");
             // Exclude special directories
-            if (path.startsWith("/proc") || path.startsWith("/sys") || path.startsWith("/run") || path.equals("/dev")
-                    || path.equals("/dev/pts"))
+            if (path.startsWith("/proc") || path.startsWith("/sys") || path.startsWith("/run")
+                    || path.startsWith("/dev"))
                 continue;
             String name = store.name();
             if (path.equals("/"))

--- a/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -69,7 +69,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
         // NOTE: FUSE's fuseblk is not evalued because used as file system representation of a FUSE block storage
         //"fuseblk" // FUSE block file system
     });
-
+    
     /**
      * Gets File System Information.
      *
@@ -116,7 +116,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
                 type = fstype.get(path);
             }
             try {
-                fsList.add(new OSFileStore(name, description, type, store.getUsableSpace(), store.getTotalSpace()));
+                fsList.add(new OSFileStore(name, path, description, type, store.getUsableSpace(), store.getTotalSpace()));
             } catch (IOException e) {
                 // get*Space() may fail for ejected CD-ROM, etc.
                 LOG.trace("", e);

--- a/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -11,6 +11,7 @@
  * Maintainers:
  * dblock[at]dblock[dot]org
  * widdis[at]gmail[dot]com
+ * enrico[dot]bianchi[at]gmail[dot]com
  *
  * Contributors:
  * https://github.com/dblock/oshi/graphs/contributors
@@ -46,7 +47,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
     private static final Logger LOG = LoggerFactory.getLogger(LinuxFileSystem.class);
 
     // Linux defines a set of virtual file systems
-    private final String[] pseudofs = new String[]{
+    private final List<String> pseudofs = Arrays.asList(new String[]{
         "sysfs", // SysFS file system
         "proc", // Proc file system
         "devtmpfs", // Dev temporary file system
@@ -67,7 +68,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
         "fusectl", // FUSE control file system
         // NOTE: FUSE's fuseblk is not evalued because used as file system representation of a FUSE block storage
         //"fuseblk" // FUSE block file system
-    };
+    });
 
     /**
      * Gets File System Information.
@@ -102,7 +103,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
             // parentheses e.g., "/ (/dev/sda1)" and "/proc (proc)"
             String path = store.toString().replace(" (" + store.name() + ")", "");
             // Exclude pseudo file systems
-            if (Arrays.asList(this.pseudofs).contains(store.name()))
+            if (this.pseudofs.contains(store.name()))
                 continue;
             String name = store.name();
             if (path.equals("/"))

--- a/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -70,6 +70,22 @@ public class LinuxFileSystem extends AbstractFileSystem {
         //"fuseblk" // FUSE block file system
     });
     
+    // System path mounted as tmpfs
+    private final List<String> tmpfsPaths = Arrays.asList(new String[]{
+        "/dev/shm",
+        "/run",
+        "/sys/fs/cgroup",
+    });
+
+    private Boolean listElementStarts(List<String> aList, String charSeq) {
+        for (String match : aList) {
+            if (match.startsWith(match)){
+                return Boolean.TRUE;
+            }
+        }
+        return Boolean.FALSE;
+    }
+    
     /**
      * Gets File System Information.
      *
@@ -102,9 +118,19 @@ public class LinuxFileSystem extends AbstractFileSystem {
             // FileStore toString starts with path, then a space, then name in
             // parentheses e.g., "/ (/dev/sda1)" and "/proc (proc)"
             String path = store.toString().replace(" (" + store.name() + ")", "");
+
             // Exclude pseudo file systems
-            if (this.pseudofs.contains(store.name()))
-                continue;
+            if (this.pseudofs.contains(store.name())) {
+                if (store.name().equals("tmpfs")) {
+                    // Exclude tmpfs system paths
+                    if (listElementStarts(this.tmpfsPaths, path)) {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            }
+
             String name = store.name();
             if (path.equals("/"))
                 name = "/";

--- a/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
+++ b/src/main/java/oshi/software/os/linux/LinuxFileSystem.java
@@ -79,7 +79,7 @@ public class LinuxFileSystem extends AbstractFileSystem {
 
     private Boolean listElementStarts(List<String> aList, String charSeq) {
         for (String match : aList) {
-            if (match.startsWith(match)){
+            if (match.startsWith(charSeq)){
                 return Boolean.TRUE;
             }
         }


### PR DESCRIPTION
Another two things:

 - I'm not sure if `store.name()` can be replaced if `path` equals "/"
 - Why informations are fetched from `/proc/self/mounts` and ` FileSystems.getDefault().getFileStores()` ?