### PR TITLE
Fix reading multiple (external) displays on Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ================
 * [#190](https://github.com/dblock/oshi/pull/190): Add VendorID and ProductID to UsbDevice - [@dbwiddis](https://github.com/dbwiddis).
 * [#193](https://github.com/dblock/oshi/pull/193): Add read/write to Windows and OS X HWDiskStores - [@dbwiddis](https://github.com/dbwiddis).
+* [#195](https://github.com/dblock/oshi/pull/195): Fixed reading multiple (in particular external) displays on Mac - [@dpagano](https://github.com/dpagano).
 * Your contribution here.
 
 2.5.1 (6/8/2016) / 2.5.2 (6/9/2016)

--- a/src/main/java/oshi/hardware/platform/mac/MacDisplay.java
+++ b/src/main/java/oshi/hardware/platform/mac/MacDisplay.java
@@ -82,6 +82,7 @@ public class MacDisplay extends AbstractDisplay {
                 }
             }
             // iterate
+            IOKit.INSTANCE.IOObjectRelease(sdService);
             sdService = IOKit.INSTANCE.IOIteratorNext(serviceIterator.getValue());
         }
         IOKit.INSTANCE.IOObjectRelease(serviceIterator.getValue());

--- a/src/main/java/oshi/hardware/platform/mac/MacDisplay.java
+++ b/src/main/java/oshi/hardware/platform/mac/MacDisplay.java
@@ -82,7 +82,7 @@ public class MacDisplay extends AbstractDisplay {
                 }
             }
             // iterate
-            sdService = IOKit.INSTANCE.IOIteratorNext(sdService);
+            sdService = IOKit.INSTANCE.IOIteratorNext(serviceIterator.getValue());
         }
         IOKit.INSTANCE.IOObjectRelease(serviceIterator.getValue());
         return displays.toArray(new Display[displays.size()]);


### PR DESCRIPTION
Looping over the different children of IODisplayConnect nodes did not work. Only the first one was returned, because the value given to IOIteratorNext in the while loop was wrong.