### PR TITLE
Don't double-release enumerator on failed WMI query.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ matrix:
   include:
     - os: linux
       jdk: oraclejdk8
-    - os: osx
-      osx_image: xcode8
+# Temporarily remove due to Travis CI backlog: https://www.traviscistatus.com/incidents/rqb906yypnk0
+#    - os: osx
+#      osx_image: xcode8

--- a/oshi-core/src/main/java/oshi/util/platform/windows/WmiUtil.java
+++ b/oshi-core/src/main/java/oshi/util/platform/windows/WmiUtil.java
@@ -460,7 +460,8 @@ public class WmiUtil {
                     pclsObj, uReturn);
             // Requested 1; if 0 objects returned, we're done
             if (0L == uReturn.getValue() || COMUtils.FAILED(hres)) {
-                enumerator.Release();
+                // Enumerator will be released by calling method so no need to
+                // release it here.
                 return;
             }
             VARIANT.ByReference vtProp = new VARIANT.ByReference();


### PR DESCRIPTION
#221 